### PR TITLE
🐛 Remove build section in `docker-compose`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ version: '3'
 
 services:
   wp:
-    build:
-      context: .
     depends_on:
     - mysql
     image: wordpress:php7.2-fpm-alpine


### PR DESCRIPTION
The plugin gets install automatically when we mount it in `/plugins`, in fact we don't even have a `Dockerfile`