### PR TITLE
✨ Add sandbox attr in iframe for amp popup support

### DIFF
--- a/likecoin/likecoin.php
+++ b/likecoin/likecoin.php
@@ -227,6 +227,7 @@ function likecoin_add_likebutton( $content ) {
 		if ( strlen( $likecoin_id ) > 0 ) {
 			$permalink   = rawurlencode( get_permalink( $post ) );
 			$widget_code = '<iframe scrolling="no" frameborder="0" ' .
+			'sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"' .
 			'style="height: 212px; width: 100%;"' .
 			'src="https://button.like.co/in/embed/' . $likecoin_id . '/button' .
 			'?referrer=' . $permalink . '&type=wp"></iframe>';

--- a/likecoin/views/user-options.php
+++ b/likecoin/views/user-options.php
@@ -132,6 +132,7 @@ function likecoin_add_button_preview( $likecoin_id ) {
 		</a>
 		<div class="centerContainer">
 		<iframe id="likecoinPreview" scrolling="no" frameborder="0"
+		sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
 		style="pointer-events: none; height: 212px; width: 500px;"
 		src="
 		<?php

--- a/likecoin/views/user-options.php
+++ b/likecoin/views/user-options.php
@@ -35,9 +35,9 @@ function likecoin_add_user_options_page() {
 		return exit();
 	}
 	// For display only, probably no security concern.
-	// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended
 	if ( isset( $_GET['settings-updated'] ) ) {
-	// phpcs:enable WordPress.Security.NonceVerification.NoNonceVerification
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
 		add_settings_error(
 			'lc_settings_messages',
 			'updated',


### PR DESCRIPTION
wordpress AMP plugin adds `sandbox` attr in iframe without allowing popup, defining `sandbox` attr in original iframe would override it