### PR TITLE
🚑 Fix user likecoin button update is broken

### DIFF
--- a/likecoin/admin/ajax.php
+++ b/likecoin/admin/ajax.php
@@ -61,7 +61,8 @@ function likecoin_update_user_id() {
 	if ( isset( $_POST['_wp_http_referer'] ) ) {
 		wp_safe_redirect( esc_url_raw( add_query_arg( 'settings-updated', '1', wp_get_referer() ) ) );
 	}
-	wp_die();
+	// wp_die breaks safe_redirect, use exit.
+	exit();
 }
 
 // we are passing these values to Matters api, no need for filtering.

--- a/likecoin/admin/likecoin.php
+++ b/likecoin/admin/likecoin.php
@@ -90,6 +90,7 @@ function likecoin_add_admin_hooks() {
 	add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'modify_plugin_action_links' );
 	add_action( 'save_post_post', 'likecoin_save_postdata' );
 	add_action( 'save_post_page', 'likecoin_save_postdata' );
+	add_action( 'admin_post_likecoin_update_user_id', 'likecoin_update_user_id' );
 	add_action( 'wp_ajax_likecoin_matters_login', 'likecoin_matters_login' );
 	add_action( 'wp_ajax_likecoin_get_error_notice', 'likecoin_get_admin_errors_restful' );
 	add_action( 'enqueue_block_editor_assets', 'likecoin_load_editor_scripts' );


### PR DESCRIPTION
Fixes https://github.com/likecoin/likecoin-wordpress/issues/77
The admin post hook was accidentally removed when refactoring, and wp_die() have funny side effect breaking redirect