### PR TITLE
✨ Lower button setting page permission, add forbidden error

### DIFF
--- a/likecoin/admin/restful.php
+++ b/likecoin/admin/restful.php
@@ -323,7 +323,7 @@ function likecoin_init_restful_service() {
 					'methods'             => 'POST',
 					'callback'            => 'likecoin_post_user_data',
 					'permission_callback' => function () {
-						return current_user_can( 'manage_options' );
+						return current_user_can( 'edit_posts' );
 					},
 				)
 			);
@@ -334,7 +334,7 @@ function likecoin_init_restful_service() {
 					'methods'             => 'GET',
 					'callback'            => 'likecoin_get_user_data',
 					'permission_callback' => function () {
-						return current_user_can( 'manage_options' );
+						return current_user_can( 'edit_posts' );
 					},
 				)
 			);

--- a/likecoin/admin/view/view.php
+++ b/likecoin/admin/view/view.php
@@ -242,7 +242,7 @@ function likecoin_display_admin_pages() {
 	$likecoin_admin_main_page = add_menu_page(
 		__( 'LikeCoin', 'likecoin' ),
 		__( 'LikeCoin', 'likecoin' ),
-		'manage_options',
+		'edit_posts',
 		'likecoin',
 		'likecoin_show_likecoin_admin_main_page_content',
 		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped,WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents,WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
@@ -257,7 +257,7 @@ function likecoin_display_admin_pages() {
 		'likecoin',
 		__( 'LikeCoin', 'likecoin' ),
 		__( 'Plugin Setting', 'likecoin' ),
-		'manage_options',
+		'edit_posts',
 		'likecoin',
 		'likecoin_load_admin_js'
 	);
@@ -268,7 +268,7 @@ function likecoin_display_admin_pages() {
 		'likecoin',
 		__( 'LikeCoin', 'likecoin' ),
 		__( 'Your LikeCoin Button', 'likecoin' ),
-		'manage_options',
+		'edit_posts',
 		'/likecoin#/likecoin-button',
 		'likecoin_load_admin_js'
 	);
@@ -301,7 +301,7 @@ function likecoin_display_admin_pages() {
 		'likecoin',
 		__( 'LikeCoin', 'likecoin' ),
 		__( 'Sponsor Likecoin', 'likecoin' ),
-		'manage_options',
+		'edit_posts',
 		'/likecoin#/sponsor-likecoin',
 		'likecoin_load_admin_js'
 	);
@@ -312,7 +312,7 @@ function likecoin_display_admin_pages() {
 		'likecoin',
 		__( 'LikeCoin', 'likecoin' ),
 		__( 'Become a Civic Liker', 'likecoin' ),
-		'manage_options',
+		'edit_posts',
 		'https://liker.land/civic?utm_source=wp-plugin'
 	);
 }

--- a/likecoin/js/admin-settings/src/components/MainSettingTable.js
+++ b/likecoin/js/admin-settings/src/components/MainSettingTable.js
@@ -20,6 +20,7 @@ function MainSettingTable(props) {
   const displayOptionRef = useRef();
   const perPostOptionEnabledRef = useRef();
   const {
+    DBIsForbidden,
     DBSiteLikerId,
     DBSiteLikerAvatar,
     DBSiteLikerDisplayName,
@@ -151,6 +152,17 @@ function MainSettingTable(props) {
     setSubmitResponse(null);
   }
   const handleDisconnect = () => {};
+
+  const forbiddenString = __('Sorry, you are not allowed to access this page.', 'likecoin');
+
+  if (DBIsForbidden) {
+    return (
+      <div className="wrap likecoin">
+        <LikecoinHeading />
+        <p>{forbiddenString}</p>
+      </div>
+    );
+  }
   return (
     <div className="wrap likecoin">
       <LikecoinHeading />


### PR DESCRIPTION
Allow accessing root page `/likecoin` without `manage_option` so that we can access `/likecoin#button`
Show permission error if user without `manage_option` access root page (only allow accessing `#button`)