### PR TITLE
✨ Fix image encoding issue and add metabox update support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   php_lint:
     working_directory: ~/likecoin-wordpress
     docker:
-      - image: composer:1.6
+      - image: composer:2.0.8
     steps:
       - checkout
       - restore_cache:
@@ -32,7 +32,7 @@ jobs:
   eslint:
     working_directory: ~/likecoin-wordpress
     docker:
-      - image: node:10
+      - image: node:14
     steps:
       - checkout
       - restore_cache:

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.3.1",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec"
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/628a481780561150481a9ec74709092b9759b3ec",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "shasum": ""
             },
             "require": {
@@ -50,12 +50,17 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-07-26T23:47:18+00:00"
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2022-06-18T07:21:10+00:00"
         }
     ],
     "packages-dev": [],
@@ -65,5 +70,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
 }

--- a/likecoin/admin/metabox.php
+++ b/likecoin/admin/metabox.php
@@ -221,6 +221,7 @@ function likecoin_get_meta_box_publish_params( $post, $force = false ) {
 			'ipfs_hash'          => isset( $matters_info['ipfs_hash'] ) ? $matters_info['ipfs_hash'] : '',
 			'iscn_hash'          => isset( $iscn_info['iscn_hash'] ) ? $iscn_info['iscn_hash'] : '',
 			'iscn_id'            => isset( $iscn_info['iscn_id'] ) ? $iscn_info['iscn_id'] : '',
+			'iscn_timestamp'     => isset( $iscn_info['last_saved_time'] ) ? $iscn_info['last_saved_time'] : '',
 			'arweave_id'         => isset( $arweave_info['arweave_id'] ) ? $arweave_info['arweave_id'] : '',
 			'arweave_ipfs_hash'  => isset( $arweave_info['ipfs_hash'] ) ? $arweave_info['ipfs_hash'] : '',
 		);
@@ -397,8 +398,8 @@ function likecoin_add_button_meta_box( $button_params ) {
 				</tr>
 			</tbody>
 		</table>
-	<?php
-}
+		<?php
+	}
 }
 
 /**
@@ -458,11 +459,13 @@ function likecoin_add_meta_box( $post, $button_params, $publish_params ) {
 			array(
 				'id'                 => $post_id,
 				'title'              => $post_title,
+				'lastModifiedTime'   => get_post_modified_time( 'U', true, $post_id ),
 				'mattersIPFSHash'    => $matters_ipfs_hash,
 				'isMattersPublished' => $matters_published_status,
 				'arweaveIPFSHash'    => $arweave_ipfs_hash,
 				'iscnHash'           => $publish_params['iscn_hash'],
 				'iscnId'             => $publish_params['iscn_id'],
+				'iscnTimestamp'      => $publish_params['iscn_timestamp'],
 				'tags'               => $post_tags,
 				'url'                => $post_url,
 				'arweaveId'          => $arweave_id,
@@ -483,6 +486,7 @@ function likecoin_add_meta_box( $post, $button_params, $publish_params ) {
 				'mainStatusRegisterISCN'  => __( 'Registering ISCN...', LC_PLUGIN_SLUG ),
 				'buttonSubmitISCN'        => __( 'Submit to ISCN', LC_PLUGIN_SLUG ),
 				'buttonRegisterISCN'      => __( 'Register ISCN', LC_PLUGIN_SLUG ),
+				'buttonUpdateISCN'        => __( 'Update ISCN', LC_PLUGIN_SLUG ),
 				'draft'                   => __( 'Draft', LC_PLUGIN_SLUG ),
 			)
 		);

--- a/likecoin/admin/post.php
+++ b/likecoin/admin/post.php
@@ -69,7 +69,6 @@ function likecoin_format_post_to_json_data( $post ) {
 		'mimeType' => $file_mime_type,
 		'data'     => base64_encode( $content ),
 	);
-
 	if ( ! empty( $feature_img_data ) ) {
 		$image_data[] = $feature_img_data;
 	}
@@ -110,7 +109,7 @@ function likecoin_get_post_content_with_relative_image_url( $post ) {
 	$images          = $dom_document->getElementsByTagName( 'img' );
 	$site_url_parsed = wp_parse_url( get_site_url() );
 	$site_host       = $site_url_parsed['host'];
-	foreach ( $images as $key=>$image ) {
+	foreach ( $images as $key => $image ) {
 		$url = $image->getAttribute( 'data-orig-file' );
 		if ( empty( $url ) ) {
 			$url = $image->getAttribute( 'src' );
@@ -121,7 +120,7 @@ function likecoin_get_post_content_with_relative_image_url( $post ) {
 		$parsed        = wp_parse_url( $url );
 		$host          = $parsed['host'];
 		if ( $attachment_id > 0 || $host === $site_host ) {
-			$image_key = $key + 1; // 0 is for featured image
+			$image_key = $key + 1; // 0 is for featured image.
 			$image->setAttribute( 'src', './' . $image_key );
 			$image->removeAttribute( 'srcset' );
 			$relative_path = ltrim( $parsed['path'], '/' );
@@ -166,7 +165,7 @@ function likecoin_get_post_thumbnail_with_relative_image_url( $post ) {
 	return array(
 		'content' => $feature_img_div,
 		'image'   => array(
-			'key' => '0', // index 0 for feature image
+			'key' => '0', // index 0 for feature image.
 			'url' => $url,
 		),
 	);

--- a/likecoin/admin/post.php
+++ b/likecoin/admin/post.php
@@ -159,8 +159,9 @@ function likecoin_get_post_thumbnail_with_relative_image_url( $post ) {
 			'image'   => null,
 		);
 	}
-	$url             = wp_get_attachment_image_url( $post_thumbnail_id, 'full' );
-	$url             = get_attached_file( $post_thumbnail_id );
+	$url = wp_get_attachment_image_url( $post_thumbnail_id, 'full' );
+	$url = get_attached_file( $post_thumbnail_id );
+	// we place all <img> in html to 1...n in a later function, 0 is used for feature.
 	$feature_img_div = '<figure><img src="./0"></figure>';
 	return array(
 		'content' => $feature_img_div,

--- a/likecoin/admin/post.php
+++ b/likecoin/admin/post.php
@@ -110,7 +110,7 @@ function likecoin_get_post_content_with_relative_image_url( $post ) {
 	$images          = $dom_document->getElementsByTagName( 'img' );
 	$site_url_parsed = wp_parse_url( get_site_url() );
 	$site_host       = $site_url_parsed['host'];
-	foreach ( $images as $image ) {
+	foreach ( $images as $key=>$image ) {
 		$url = $image->getAttribute( 'data-orig-file' );
 		if ( empty( $url ) ) {
 			$url = $image->getAttribute( 'src' );
@@ -121,7 +121,8 @@ function likecoin_get_post_content_with_relative_image_url( $post ) {
 		$parsed        = wp_parse_url( $url );
 		$host          = $parsed['host'];
 		if ( $attachment_id > 0 || $host === $site_host ) {
-			$image->setAttribute( 'src', '.' . $parsed['path'] );
+			$image_key = $key + 1; // 0 is for featured image
+			$image->setAttribute( 'src', './' . $image_key );
 			$image->removeAttribute( 'srcset' );
 			$relative_path = ltrim( $parsed['path'], '/' );
 			$image_path    = ABSPATH . $relative_path;
@@ -129,7 +130,7 @@ function likecoin_get_post_content_with_relative_image_url( $post ) {
 				$image_path = get_attached_file( $attachment_id );
 			}
 			$image_urls[] = array(
-				'key' => $relative_path,
+				'key' => $image_key,
 				'url' => $image_path,
 			);
 		}
@@ -160,14 +161,12 @@ function likecoin_get_post_thumbnail_with_relative_image_url( $post ) {
 		);
 	}
 	$url             = wp_get_attachment_image_url( $post_thumbnail_id, 'full' );
-	$parsed          = wp_parse_url( $url );
 	$url             = get_attached_file( $post_thumbnail_id );
-	$feature_img_div = '<figure><img src=".' . esc_url( $parsed['path'] ) . '"></figure>';
-	$relative_path   = ltrim( $parsed['path'], '/' );
+	$feature_img_div = '<figure><img src="./0"></figure>';
 	return array(
 		'content' => $feature_img_div,
 		'image'   => array(
-			'key' => $relative_path,
+			'key' => '0', // index 0 for feature image
 			'url' => $url,
 		),
 	);

--- a/likecoin/admin/view/restful.php
+++ b/likecoin/admin/view/restful.php
@@ -367,7 +367,6 @@ function likecoin_get_iscn_full_info( $request ) {
 		$iscn_full_info['iscnHash'] = $iscn_info['iscn_hash'];
 		$iscn_full_info['iscnId']   = $iscn_info['iscn_id'];
 		// iscnVersion should be taken from chain API.
-		$iscn_full_info['timeZone']      = $timezone;
 		$iscn_full_info['iscnTimestamp'] = $iscn_info['last_saved_time'];
 		$iscn_full_info['iscnVersion']   = $iscn_info['iscn_version'];
 	}

--- a/likecoin/admin/view/restful.php
+++ b/likecoin/admin/view/restful.php
@@ -55,10 +55,10 @@ function likecoin_post_main_plugin_options( $request ) {
 	$per_post_option_enabled = $params['perPostOptionEnabled'];
 	$liker_infos             = $params['siteLikerInfos'];
 
-	$plugin_options['site_likecoin_id_enbled']        = $site_liker_id_enabled;
-	$plugin_options['button_display_option']          = $display_option;
-	$plugin_options['button_display_author_override'] = $per_post_option_enabled;
-	$plugin_options['site_likecoin_user']             = $liker_infos;
+	$plugin_options['site_likecoin_id_enbled']         = $site_liker_id_enabled;
+	$plugin_options[ LC_OPTION_BUTTON_DISPLAY_OPTION ] = $display_option;
+	$plugin_options['button_display_author_override']  = $per_post_option_enabled;
+	$plugin_options['site_likecoin_user']              = $liker_infos;
 
 	update_option( LC_BUTTON_OPTION_NAME, $plugin_options );
 	$plugin_options = get_option( LC_BUTTON_OPTION_NAME );

--- a/likecoin/js/admin-settings/src/components/LikecoinInfoTable.js
+++ b/likecoin/js/admin-settings/src/components/LikecoinInfoTable.js
@@ -22,7 +22,7 @@ function LikecoinInfoTable(props) {
               <td>
                 <div className="avatarWrapper">
                   {!props.isLoading
-                    && props.likerAvatar.length > 0
+                    && props.likerAvatar
                     && props.likerAvatar !== '-' && (
                       <img
                         id="likecoinAvatar"
@@ -31,7 +31,7 @@ function LikecoinInfoTable(props) {
                         alt="Avatar"
                       />
                   )}
-                  {props.likerIdValue.length > 0 && props.likerIdValue !== '-'
+                  {props.likerIdValue && props.likerIdValue !== '-'
                     && !props.isChangingTypingLiker && (
                       <a
                         id="likecoinId"
@@ -43,7 +43,7 @@ function LikecoinInfoTable(props) {
                         {props.likerIdValue}
                       </a>
                   )}
-                  {(props.likerIdValue.length === 0 || props.likerIdValue === '-'
+                  {(!props.likerIdValue || props.likerIdValue === '-'
                     || props.isChangingTypingLiker) && (
                     <div>
                       <input
@@ -106,7 +106,7 @@ function LikecoinInfoTable(props) {
           </tbody>
         </table>
         <section className="likecoin loading">
-          {props.likerIdValue.length !== 0
+          {props.likerIdValue
             && props.isLoading
             && __('Loading...', 'likecoin')}
         </section>

--- a/likecoin/js/admin-settings/src/components/MainSettingTable.js
+++ b/likecoin/js/admin-settings/src/components/MainSettingTable.js
@@ -61,6 +61,7 @@ function MainSettingTable(props) {
     () => debounce(async (likerId) => {
       setSavedSuccessful(false);
       setIsLoading(true);
+      if (!likerId) return;
       try {
         const response = await axios.get(
           `https://api.${props.likecoHost}/users/id/${likerId}/min`,

--- a/likecoin/js/admin-settings/src/store/site-likerInfo-store.js
+++ b/likecoin/js/admin-settings/src/store/site-likerInfo-store.js
@@ -1,5 +1,5 @@
-import { createReduxStore, register } from '@wordpress/data';
 import axios from 'axios';
+import { createAndRegisterReduxStore } from './util';
 
 // eslint-disable-next-line import/prefer-default-export
 export const SITE_LIKER_INFO_STORE_NAME = 'likecoin/site_liker_info';
@@ -147,9 +147,4 @@ const storeConfig = {
   actions,
 };
 
-const siteLikerInfoStore = createReduxStore(
-  SITE_LIKER_INFO_STORE_NAME,
-  storeConfig,
-);
-
-register(siteLikerInfoStore);
+createAndRegisterReduxStore(SITE_LIKER_INFO_STORE_NAME, storeConfig);

--- a/likecoin/js/admin-settings/src/store/site-likerInfo-store.js
+++ b/likecoin/js/admin-settings/src/store/site-likerInfo-store.js
@@ -91,6 +91,7 @@ const resolvers = {
       if (!siteLikerInfo.button_display_option) {
         siteLikerInfo.button_display_option = INITIAL_STATE.DBDisplayOptionSelected;
       }
+      if (!siteLikerInfo.site_likecoin_user) siteLikerInfo.site_likecoin_user = {};
       return actions.setSiteLikerInfo(siteLikerInfo);
     } catch (error) {
       return actions.setHTTPError(error);

--- a/likecoin/js/admin-settings/src/store/site-publish-store.js
+++ b/likecoin/js/admin-settings/src/store/site-publish-store.js
@@ -1,5 +1,5 @@
-import { createReduxStore, register } from '@wordpress/data';
 import axios from 'axios';
+import { createAndRegisterReduxStore } from './util';
 
 // eslint-disable-next-line import/prefer-default-export
 export const SITE_PUBLISH_STORE_NAME = 'likecoin/site_publish';
@@ -180,9 +180,4 @@ const storeConfig = {
   actions,
 };
 
-const siteMattersStore = createReduxStore(
-  SITE_PUBLISH_STORE_NAME,
-  storeConfig,
-);
-
-register(siteMattersStore);
+createAndRegisterReduxStore(SITE_PUBLISH_STORE_NAME, storeConfig);

--- a/likecoin/js/admin-settings/src/store/user-likerInfo-store.js
+++ b/likecoin/js/admin-settings/src/store/user-likerInfo-store.js
@@ -1,5 +1,5 @@
-import { createReduxStore, register } from '@wordpress/data';
 import axios from 'axios';
+import { createAndRegisterReduxStore } from './util';
 
 // eslint-disable-next-line import/prefer-default-export
 export const USER_LIKER_INFO_STORE_NAME = 'likecoin/user_liker_info';
@@ -105,9 +105,4 @@ const storeConfig = {
   actions,
 };
 
-const userLikerInfoStore = createReduxStore(
-  USER_LIKER_INFO_STORE_NAME,
-  storeConfig,
-);
-
-register(userLikerInfoStore);
+createAndRegisterReduxStore(USER_LIKER_INFO_STORE_NAME, storeConfig);

--- a/likecoin/js/admin-settings/src/store/util.js
+++ b/likecoin/js/admin-settings/src/store/util.js
@@ -1,0 +1,17 @@
+import { createReduxStore, registerStore, register } from '@wordpress/data';
+
+export function createAndRegisterReduxStore(storeName, storeConfig) {
+  if (createReduxStore) {
+    const store = createReduxStore(
+      storeName,
+      storeConfig,
+    );
+
+    register(store);
+    return store;
+  }
+  registerStore(storeName, storeConfig);
+  return storeName;
+}
+
+export default createAndRegisterReduxStore;

--- a/likecoin/js/admin-settings/src/store/web-monetization-store.js
+++ b/likecoin/js/admin-settings/src/store/web-monetization-store.js
@@ -1,5 +1,5 @@
-import { createReduxStore, register } from '@wordpress/data';
 import axios from 'axios';
+import { createAndRegisterReduxStore } from './util';
 
 // eslint-disable-next-line import/prefer-default-export
 export const WEB_MONETIZATION_STORE_NAME = 'likecoin/web_monetization';
@@ -95,9 +95,4 @@ const storeConfig = {
   actions,
 };
 
-const webMonetizationStore = createReduxStore(
-  WEB_MONETIZATION_STORE_NAME,
-  storeConfig,
-);
-
-register(webMonetizationStore);
+createAndRegisterReduxStore(WEB_MONETIZATION_STORE_NAME, storeConfig);

--- a/likecoin/js/admin/likecoin_metabox.js
+++ b/likecoin/js/admin/likecoin_metabox.js
@@ -25,6 +25,7 @@ const {
   mainStatusRegisterISCN,
   buttonSubmitISCN,
   buttonRegisterISCN,
+  buttonUpdateISCN,
   draft,
 } = lcStringInfo;
 const MAIN_STATUS_TEXT_MAP = {
@@ -80,6 +81,8 @@ async function onRefreshPublishStatus(e) {
     iscnHash,
     iscnId,
     isMattersPublished,
+    lastModifiedTime,
+    iscnTimestamp,
   } = lcPostInfo;
   const res = await jQuery.ajax({
     type: 'POST',
@@ -103,16 +106,20 @@ async function onRefreshPublishStatus(e) {
       href: `https://app.${window.wpApiSettings.likecoHost}/view/${iscnIdString}`,
     });
     updateFieldStatusElement(ISCNStatusTextField, ISCNLink);
-  } else if ( // show button
+  }
+  if ( // show button
     isWordpressPublished === 'publish'
     && (lcPostInfo.mainStatus === 'initial' || lcPostInfo.mainStatus.includes('failed'))
+    && (!iscnId || lastModifiedTime > iscnTimestamp)
   ) {
     updateMainTitleField(
       'iscn-status-orange',
       lcStringInfo.mainTitleIntermediate,
     );
+    let text = arweave.url ? buttonRegisterISCN : buttonSubmitISCN;
+    if (iscnId) text = buttonUpdateISCN;
     const arweaveISCNBtn = createElementWithAttrbutes('button', {
-      text: arweave.url ? buttonRegisterISCN : buttonSubmitISCN,
+      text,
       className: 'button button-primary',
       id: 'lcArweaveUploadBtn',
     });
@@ -279,7 +286,8 @@ async function onSubmitToISCN(e) {
   lcPostInfo.mainStatus = 'onRegisterISCN';
   updateFieldStatusText(ISCNStatusTextField, getStatusText(lcPostInfo.mainStatus));
   const redirectString = encodeURIComponent(siteurl);
-  const likeCoISCNWidget = `${ISCN_WIDGET_ORIGIN}/in/widget/iscn-ar?opener=1&blocking=1&mint=1&redirect_uri=${redirectString}`;
+  const iscnId = encodeURIComponent(lcPostInfo.iscnId || '');
+  const likeCoISCNWidget = `${ISCN_WIDGET_ORIGIN}/in/widget/iscn-ar?opener=1&blocking=1&mint=1&redirect_uri=${redirectString}&iscn_id=${iscnId}`;
   const ISCNWindow = window.open(
     likeCoISCNWidget,
     'likeCoISCNWindow',

--- a/likecoin/js/sidebar/src/store/iscn-info-store.js
+++ b/likecoin/js/sidebar/src/store/iscn-info-store.js
@@ -1,5 +1,5 @@
-import { createReduxStore, register } from '@wordpress/data';
 import axios from 'axios';
+import { createAndRegisterReduxStore } from './util';
 
 const {
   root, nonce, postId, likecoHost,
@@ -264,9 +264,5 @@ const storeConfig = {
   actions,
 };
 
-const iscnInfoStore = createReduxStore(
-  ISCN_INFO_STORE_NAME,
-  storeConfig,
-);
+createAndRegisterReduxStore(ISCN_INFO_STORE_NAME, storeConfig);
 
-register(iscnInfoStore);

--- a/likecoin/js/sidebar/src/store/util.js
+++ b/likecoin/js/sidebar/src/store/util.js
@@ -1,0 +1,17 @@
+import { createReduxStore, registerStore, register } from '@wordpress/data';
+
+export function createAndRegisterReduxStore(storeName, storeConfig) {
+  if (createReduxStore) {
+    const store = createReduxStore(
+      storeName,
+      storeConfig,
+    );
+
+    register(store);
+    return store;
+  }
+  registerStore(storeName, storeConfig);
+  return storeName;
+}
+
+export default createAndRegisterReduxStore;

--- a/likecoin/likecoin.php
+++ b/likecoin/likecoin.php
@@ -55,6 +55,13 @@ function likecoin_handle_init_and_upgrade() {
 	global $charset_collate;
 	$version = get_option( 'likecoin_plugin_version', LC_PLUGIN_VERSION );
 
+	// init button display option to 'post'.
+	$button_option = get_option( LC_BUTTON_OPTION_NAME, array() );
+	if ( ! isset( $button_option[ LC_OPTION_BUTTON_DISPLAY_OPTION ] ) ) {
+		$button_option[ LC_OPTION_BUTTON_DISPLAY_OPTION ] = 'post';
+		update_option( LC_BUTTON_OPTION_NAME, $button_option );
+	}
+
 	if ( version_compare( $version, '1.1' ) < 0 ) {
 		delete_metadata( 'user', 0, 'lc_widget_option', '', true );
 		delete_metadata( 'user', 0, 'lc_widget_position', '', true );


### PR DESCRIPTION
- Stub `createReduxStore` if not exists (exists since WP > 5.7)
- Avoid handling of utf8 filename by using array index as img src and arweave key..
- Add update iscn button in metabox
- Fix undefined var right after install break admin panel
- Add default option "post only" for button display setting