### PR TITLE
Fix Likecoin shortcode display when widgets are disabled on page/post

### DIFF
--- a/likecoin/public/likecoin-button.php
+++ b/likecoin/public/likecoin-button.php
@@ -79,7 +79,7 @@ function likecoin_add_likecoin_meta_header() {
  *
  * @param string| $likecoin_id The Liker ID of owner of LikeCoin Button.
  */
-function likecoin_add_likebutton( $likecoin_id = '' ) {
+function likecoin_add_likebutton( $likecoin_id = '', $shortcode = false ) {
 	global $post;
 	$option = get_option( LC_BUTTON_OPTION_NAME );
 	$type   = $option[ LC_OPTION_BUTTON_DISPLAY_OPTION ];
@@ -126,7 +126,7 @@ function likecoin_add_likebutton( $likecoin_id = '' ) {
 		}
 	};
 	$widget_is_enabled = ! empty( $widget_position ) && 'none' !== $widget_position;
-	if ( ! $widget_is_enabled ) {
+	if ( ! $widget_is_enabled && $shortcode == false ) {
 		return '';
 	}
 
@@ -181,5 +181,5 @@ function likecoin_likecoin_shortcode( $atts = array(), $content = null, $tag = '
 		),
 		$atts
 	);
-	return likecoin_add_likebutton( $filtered['liker-id'] );
+	return likecoin_add_likebutton( $filtered['liker-id'], true );
 }

--- a/likecoin/public/likecoin-button.php
+++ b/likecoin/public/likecoin-button.php
@@ -77,7 +77,8 @@ function likecoin_add_likecoin_meta_header() {
 /**
  * Add LikeCoin Button if LikerId exist
  *
- * @param string| $likecoin_id The Liker ID of owner of LikeCoin Button.
+ * @param string|  $likecoin_id The Liker ID of owner of LikeCoin Button.
+ * @param boolean| $is_shortcode If the button is added by shortcode, ignores $widget_is_enabled if true.
  */
 function likecoin_add_likebutton( $likecoin_id = '', $is_shortcode = false ) {
 	global $post;

--- a/likecoin/public/likecoin-button.php
+++ b/likecoin/public/likecoin-button.php
@@ -79,7 +79,7 @@ function likecoin_add_likecoin_meta_header() {
  *
  * @param string| $likecoin_id The Liker ID of owner of LikeCoin Button.
  */
-function likecoin_add_likebutton( $likecoin_id = '', $shortcode = false ) {
+function likecoin_add_likebutton( $likecoin_id = '', $is_shortcode = false ) {
 	global $post;
 	$option = get_option( LC_BUTTON_OPTION_NAME );
 	$type   = $option[ LC_OPTION_BUTTON_DISPLAY_OPTION ];
@@ -126,7 +126,7 @@ function likecoin_add_likebutton( $likecoin_id = '', $shortcode = false ) {
 		}
 	};
 	$widget_is_enabled = ! empty( $widget_position ) && 'none' !== $widget_position;
-	if ( ! $widget_is_enabled && $shortcode == false ) {
+	if ( ! $widget_is_enabled && ! $is_shortcode ) {
 		return '';
 	}
 


### PR DESCRIPTION
Bug report

If I insert shortcode `[likecoin]` anywhere in posts or pages, and I have "LikeCoin widget" options disabled (Show in Posts/Pages), the shortcode will not display.
I added a param to `likecoin_add_likebutton` to consider shortcode when displaying the widget.